### PR TITLE
(misc) Fix usage of legacy File#exists?

### DIFF
--- a/agent/filemgr.rb
+++ b/agent/filemgr.rb
@@ -46,7 +46,7 @@ module MCollective
         reply[:uid] = 0
         reply[:gid] = 0
 
-        if File.exists?(file)
+        if File.exist?(file)
           Log.debug("Asked for status of '#{file}' - it is present")
           reply[:output] = "present"
           reply[:present] = 1
@@ -91,7 +91,7 @@ module MCollective
       def remove
         file = get_filename
 
-        if File.exists?(file) || File.symlink?(file)
+        if File.exist?(file) || File.symlink?(file)
           begin
             FileUtils.rm(file)
             Log.debug("Removed file '#{file}'")

--- a/spec/agent/filemgr_agent_spec.rb
+++ b/spec/agent/filemgr_agent_spec.rb
@@ -40,20 +40,20 @@ module MCollective
 
       describe "remove" do
         it "should not try to remove a file that isn't present" do
-          File.expects(:exists?).with("/tmp/foo").returns(false)
+          File.expects(:exist?).with("/tmp/foo").returns(false)
           result = @agent.call(:remove, :file => "/tmp/foo")
           result.should be_aborted_error
         end
 
         it "should fail if it can't remove the file" do
-          File.expects(:exists?).with("/tmp/foo").returns(true)
+          File.expects(:exist?).with("/tmp/foo").returns(true)
           FileUtils.expects(:rm).raises("error")
           result = @agent.call(:remove, :file => "/tmp/foo")
           result.should be_aborted_error
         end
 
         it "should remove a file" do
-          File.expects(:exists?).with("/tmp/foo").returns(true)
+          File.expects(:exist?).with("/tmp/foo").returns(true)
           FileUtils.expects(:rm)
           result = @agent.call(:remove, :file => "/tmp/foo")
           result.should be_successful
@@ -62,7 +62,7 @@ module MCollective
 
       describe "status" do
         it "should fail if the file isn't present" do
-          File.expects(:exists?).with("/tmp/foo").returns(false)
+          File.expects(:exist?).with("/tmp/foo").returns(false)
           result = @agent.call(:status, :file => "/tmp/foo")
           result.should be_aborted_error
         end
@@ -70,7 +70,7 @@ module MCollective
         it "should return the file status" do
           stat = mock
 
-          File.expects(:exists?).with("/tmp/foo").returns(true)
+          File.expects(:exist?).with("/tmp/foo").returns(true)
           File.expects(:symlink?).returns(false)
           File.expects(:stat).with("/tmp/foo").returns(stat)
           File.stubs(:read).returns("")


### PR DESCRIPTION
The #exists? method was removed in Ruby 3.2.  exist? is to be used
instead.
